### PR TITLE
Add a snap package (https://snapcraft.io)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
   },
   "build": {
     "appId": "org.develar.doubanfm",
-    "app-category-type": "public.app-category.music",
+    "mac": {
+      "category": "music",
+      "target": ["dmg"]
+    },
     "dmg": {
       "contents": [
         {
@@ -45,14 +48,21 @@
         }
       ]
     },
-    "win": {
+    "squirrelWindows": {
       "iconUrl": "https://raw.githubusercontent.com/xwartz/PupaFM/master/build/icon.ico",
       "remoteReleases": true
     },
     "linux": {
       "target": [
+        "snap",
         "deb",
         "AppImage"
+      ]
+    },
+    "snap": {
+      "plugs": [
+        "default",
+        "desktop"
       ]
     }
   },
@@ -89,7 +99,7 @@
     "babel-register": "^6.7.2",
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",
-    "electron-builder": "^5.14.2",
+    "electron-builder": "19.46.9",
     "electron-prebuilt": "^1.2.8",
     "eslint": "^2.13.1",
     "eslint-config-standard": "^5.3.5",


### PR DESCRIPTION
Hi! I put together this PR to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 16.04 and 17.10, but it should work just as well on Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run dist -- -l` it will create `dist/pupafm_1.2.2_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous pupafm_1.2.2_amd64.snap`

Run with `pupafm` or find it in the launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "pupafm" name](https://dashboard.snapcraft.io/register-snap/?name=pupafm).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push PupaFM out with:
`snapcraft push pupafm_1.2.2_amd64.snap --release stable`

(You can also push to the Snap Store [programmatically from Travis](https://docs.snapcraft.io/build-snaps/ci-integration#using-travis).)

Signed-off-by: Evan Dandrea \<evan@dandrea.co.uk\>